### PR TITLE
chore(deploy): update deploy scripts in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "clean": "turbo run clean",
-    "deploy": "npm publish --workspaces"
+    "deploy": "turbo run deploy"
   },
   "devDependencies": {
     "turbo": "^2.5.4",

--- a/packages/filament/package.json
+++ b/packages/filament/package.json
@@ -18,7 +18,8 @@
     "clean": "rm -rf dist",
     "test": "echo \"No tests specified\"",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "deploy": "npm publish"
   },
   "devDependencies": {
     "typescript": "^5.8.3"

--- a/packages/warp/package.json
+++ b/packages/warp/package.json
@@ -18,7 +18,8 @@
     "clean": "rm -rf dist",
     "test": "echo \"No tests specified\"",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "deploy": "npm publish"
   },
   "dependencies": {
     "@relational-fabric/filament": "*"

--- a/packages/weft/package.json
+++ b/packages/weft/package.json
@@ -18,7 +18,8 @@
     "clean": "rm -rf dist",
     "test": "echo \"No tests specified\"",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "deploy": "npm publish"
   },
   "dependencies": {
     "@relational-fabric/filament": "*"

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,12 @@
         "build",
         "^test"
       ]
+    },
+    "deploy": {
+      "dependsOn": [
+        "build",
+        "^deploy"
+      ]
     }
   }
 }


### PR DESCRIPTION
- Replaced the "deploy" script in the root `package.json` to use "turbo run deploy" for improved deployment management.
- Added "deploy" scripts to the `package.json` files of the filament, warp, and weft packages to facilitate publishing via npm.
- Ensured that the deployment process is streamlined across all packages.